### PR TITLE
Add Node 25 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_NODE_VERSION: 24.x
+  DEFAULT_NODE_VERSION: 25.x
 
 jobs:
 
@@ -37,6 +37,7 @@ jobs:
           - 20.x
           - 22.x
           - 24.x
+          - 25.x
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ permissions:
   id-token: write
 
 env:
-  DEFAULT_NODE_VERSION: 24.x
+  DEFAULT_NODE_VERSION: 25.x
 
 jobs:
 


### PR DESCRIPTION
This also changes the default version to 25 for running the other CI steps, to take advantage of improvements in Node. The tests still run on all supported Node versions.